### PR TITLE
[EAM-414] Locations on Global Search

### DIFF
--- a/eam-light-backendejb/src/main/java/ch/cern/cmms/eamlightejb/index/IndexEJB.java
+++ b/eam-light-backendejb/src/main/java/ch/cern/cmms/eamlightejb/index/IndexEJB.java
@@ -111,6 +111,8 @@ public class IndexEJB {
 
         sj.add("\'S\'");
 
+        sj.add("\'L\'");
+
         obj_obtypeIN.append(sj.toString());
 
         StringJoiner sjQuery = new StringJoiner(" union ");

--- a/eam-light-backendweb/src/main/java/ch/cern/cmms/eamlightweb/index/IndexGrids.java
+++ b/eam-light-backendweb/src/main/java/ch/cern/cmms/eamlightweb/index/IndexGrids.java
@@ -87,6 +87,7 @@ public class IndexGrids {
         runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"BEGINS", "84", "OSOBJA", "85", "A")));
         runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"BEGINS", "113", "OSOBJP", "111", "P")));
         runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"BEGINS", "88", "OSOBJS", "89", "S")));
+        runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"BEGINS", "118", "OSOBJL", "117", "L")));
         runnables.add(() -> result.addAll(searchParts(inforContext, keyword, "BEGINS")));
 
         inforClient.getTools().processRunnables(runnables);
@@ -101,6 +102,7 @@ public class IndexGrids {
         runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"EQUALS", "84", "OSOBJA", "85", "A")));
         runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"EQUALS", "113", "OSOBJP", "111", "P")));
         runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"EQUALS", "88", "OSOBJS", "89", "S")));
+        runnables.add(() -> result.addAll(searchEquipment(inforContext, keyword,"EQUALS", "118", "OSOBJL", "117", "L")));
         runnables.add(() -> result.addAll(searchParts(inforContext, keyword, "EQUALS")));
 
         inforClient.getTools().processRunnables(runnables);


### PR DESCRIPTION
**NOTE**: global search when a database is not configured is not working, so unable to test grid id/grid name/dataspy id configuration. This PR is tested to be working on CERN EAM Light with a database configured.

**Please make sure to merge https://github.com/cern-eam/eam-light-frontend/pull/47**