### PR TITLE
[EAM-1774] Added incomplete checklist confirmation

### DIFF
--- a/eam-light-backendweb/src/main/java/ch/cern/cmms/eamlightweb/workorders/WorkOrderRest.java
+++ b/eam-light-backendweb/src/main/java/ch/cern/cmms/eamlightweb/workorders/WorkOrderRest.java
@@ -70,6 +70,8 @@ public class WorkOrderRest extends EAMLightController {
 	public Response updateWorkOrder(WorkOrder workOrder) {
 		try {
 			assumeEquipmentMonoOrg(workOrder);
+			// We confirm the following on the front-end
+			workOrder.setConfirmedIncompleteChecklist(true);
 			inforClient.getWorkOrderService().updateWorkOrder(authenticationTools.getInforContext(), workOrder);
 			// Read again the work order
 			return ok(inforClient.getWorkOrderService().readWorkOrder(authenticationTools.getInforContext(), workOrder.getNumber()));


### PR DESCRIPTION
Adds the incomplete checklist confirmation flag to the work order when updating, as this is handled on the front end, and the request shouldn't fire if this flag would be false