### PR TITLE
[EAM-1953] Add endpoint that maps equipment to otherid from workorder

### DIFF
--- a/eam-light-backendweb/src/main/java/ch/cern/cmms/eamlightweb/workorders/misc/WorkOrderMisc.java
+++ b/eam-light-backendweb/src/main/java/ch/cern/cmms/eamlightweb/workorders/misc/WorkOrderMisc.java
@@ -18,6 +18,7 @@ import ch.cern.cmms.eamlightweb.tools.EAMLightController;
 import ch.cern.eam.wshub.core.client.InforClient;
 import ch.cern.cmms.eamlightweb.tools.interceptors.RESTLoggingInterceptor;
 import ch.cern.eam.wshub.core.services.grids.entities.GridRequest;
+import ch.cern.eam.wshub.core.services.grids.entities.GridRequestFilter;
 import ch.cern.eam.wshub.core.tools.InforException;
 import net.datastream.schemas.mp_results.mp7336_001.AdditionalWOEquipDetails;
 
@@ -88,6 +89,23 @@ public class WorkOrderMisc extends EAMLightController {
 		try {
 			final AdditionalWOEquipDetails woEquipLinearDetails = inforClient.getWorkOrderMiscService().getEquipLinearDetails(authenticationTools.getR5InforContext(), eqCode);
 			return ok(woEquipLinearDetails);
+		} catch (InforException e) {
+			return badRequest(e);
+		} catch(Exception e) {
+			return serverError(e);
+		}
+	}
+
+	@GET
+	@Path("/otherid/{workorder}")
+	@Produces("application/json")
+	public Response getWOEqOtherIds(@PathParam("workorder") String workorder) {
+		try {
+			GridRequest gridRequestWoEqOi = new GridRequest("UUOIEQ", 1000);
+			gridRequestWoEqOi.addFilter("workorder", workorder, "EQUALS", GridRequestFilter.JOINER.AND);
+			Map<String, String> eqToOtherId = inforClient.getTools().getGridTools().convertGridResultToMap("equipment", "otherid",
+									inforClient.getGridsService().executeQuery(authenticationTools.getR5InforContext(), gridRequestWoEqOi));
+			return ok(eqToOtherId);
 		} catch (InforException e) {
 			return badRequest(e);
 		} catch(Exception e) {


### PR DESCRIPTION
The 'UUOIEQ' grid contains 'equipment', 'otherid' and 'workorder'.
The grid fetches all the equipments listed in the checklists.
It is important that this grid is queried with some filter,
otherwise it is expensive to run.

Related to https://github.com/cern-eam/eam-components/pull/117 and https://github.com/cern-eam/eam-light-frontend/pull/147